### PR TITLE
fix: add echo to init command

### DIFF
--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -46,7 +46,8 @@ exec:
     ssh -oStrictHostKeyChecking=no \
                  -p ${PORT} \
                  ${EXTRA_FLAGS} \
-                 "${HOST}" 
+                 "${HOST}" \
+                 echo "Successfully initialized connection to ${HOST}"
 
     if [ $? != 0 ]; then
       >&2 echo "Unexpected non-zero ssh exit code"


### PR DESCRIPTION
Without a command to run, the init process logs in to the remote host and hangs there waiting for user input. Since this is a non-interactive command happening in the background, it will simply wait forever or until something forcibly terminates the SSH connection. Since there is no debug output available in the UI, the user receives no feedback on what's happening. Adding the provider from the command line makes it fairly obvious though.

```
PS C:\Users\shaun> devpod.cmd provider add https://github.com/loft-sh/devpod-provider-ssh/releases/download/v0.0.3/provider.yaml --debug --use
14:21:46 info Download provider https://github.com/loft-sh/devpod-provider-ssh/releases/download/v0.0.3/provider.yaml...
14:21:47 done Successfully installed provider ssh
14:21:47 info The SSH Host to connect to. Example: my-user@my-domain.com

? Please enter a value for HOST myhost.local
14:21:53 debug Run init provider command: ssh -oStrictHostKeyChecking=no \
             -p ${PORT} \
             ${EXTRA_FLAGS} \
             "${HOST}"

if [ $? != 0 ]; then
  >&2 echo "Unexpected non-zero ssh exit code"
  >&2 echo "Please make sure you have configured the correct SSH host"
  >&2 echo "and the following command can be executed on your system:"
  >&2 echo ssh -oStrictHostKeyChecking=no -p "${PORT}" "${HOST}"
  exit 1
fi

14:21:53 info Welcome to Ubuntu 22.04.1 LTS (GNU/Linux 5.19.0-38-generic x86_64)
14:21:53 info
14:21:53 info  * Documentation:  https://help.ubuntu.com
14:21:53 info  * Management:     https://landscape.canonical.com
14:21:53 info  * Support:        https://ubuntu.com/advantage
14:21:53 info
14:21:53 info 201 updates can be applied immediately.
14:21:53 info To see these additional updates run: apt list --upgradable
14:21:53 info
14:21:53 info *** System restart required ***
14:21:53 info Last login: Sun May 28 14:10:11 2023 from ...
```

This PR adds an `echo` to indicate that the connection was successful and allows `ssh` to finish with a proper exit code:

```
PS C:\Users\shaun> devpod.cmd provider add ...\provider.yaml --debug --use
14:23:05 done Successfully installed provider ssh
14:23:05 info The SSH Host to connect to. Example: my-user@my-domain.com

? Please enter a value for HOST myhost.local

14:23:10 debug Run init provider command: ssh -oStrictHostKeyChecking=no \
             -p ${PORT} \
             ${EXTRA_FLAGS} \
             "${HOST}" \
             echo "Successfully initialized connection to ${HOST}"

if [ $? != 0 ]; then
  >&2 echo "Unexpected non-zero ssh exit code"
  >&2 echo "Please make sure you have configured the correct SSH host"
  >&2 echo "and the following command can be executed on your system:"
  >&2 echo ssh -oStrictHostKeyChecking=no -p "${PORT}" "${HOST}"
  exit 1
fi

14:23:10 info Successfully initialized connection to myhost.local
14:23:10 done Successfully configured provider 'ssh'
```