### PR TITLE
fix: add proper init checks to ssh provider

### DIFF
--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -54,7 +54,13 @@ exec:
                  -p ${PORT} \
                  ${EXTRA_FLAGS} \
                  "${HOST}" \
-                 echo "Successfully initialized connection to ${HOST}"
+                 sh -c "\"if [ \$(id -ru) -eq 0 ]; then exit 0; fi; \
+                        if (! mkdir -p ${AGENT_PATH} || [ ! -w ${AGENT_PATH} ]) && ! sudo -nl >/dev/null; then \
+                          echo $AGENT_PATH is not writable, passwordless sudo or root user required; exit 1; \
+                          fi; \
+                        if ! command -v ${DOCKER_PATH} >/dev/null && ! sudo -nl >/dev/null; then \
+                          echo $DOCKER_PATH not found, passwordless sudo or root user required; exit 1; \
+                        fi "\"
 
     if [ $? != 0 ]; then
       >&2 echo "Unexpected non-zero ssh exit code"

--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -55,7 +55,7 @@ exec:
                  ${EXTRA_FLAGS} \
                  "${HOST}" \
                  sh -c "\"if [ \$(id -ru) -eq 0 ]; then exit 0; fi; \
-                        if (! mkdir -p ${AGENT_PATH} || [ ! -w ${AGENT_PATH} ]) && ! sudo -nl >/dev/null; then \
+                        if (! mkdir -p \$(dirname ${AGENT_PATH}) || [ ! -w \$(dirname ${AGENT_PATH}) ]) && ! sudo -nl >/dev/null; then \
                           echo $AGENT_PATH is not writable, passwordless sudo or root user required; exit 1; \
                           fi; \
                         if ! command -v ${DOCKER_PATH} >/dev/null && ! sudo -nl >/dev/null; then \


### PR DESCRIPTION
This fix adds proper checks during the init:

* if root -> all ok
* if not root: check if I can write to AGENT_PATH
* if not root: check if DOCKER_PATH exist and is executable
* If any of those fails, ask for sudo, if sudo needs a password, we fail

This will:

Fix https://github.com/loft-sh/devpod/issues/396
Fix https://github.com/loft-sh/devpod/issues/350
Resolves ENG-1576
Resolves ENG-1474