### PR TITLE
fix(exec): fallback logic for non-posix shell incompatibilities

### DIFF
--- a/e2e/tests/provider/provider.go
+++ b/e2e/tests/provider/provider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 
@@ -10,7 +11,6 @@ import (
 )
 
 var _ = ginkgo.Describe("[e2e]: devpod provider ssh test suite", ginkgo.Ordered, func() {
-
 	ginkgo.Context("testing /kubeletinfo endpoint", ginkgo.Label("e2e"), ginkgo.Ordered, func() {
 		ginkgo.It("should fail the init", func() {
 			cmd := exec.Command("../release/devpod-provider-ssh-linux-amd64", "init")
@@ -98,7 +98,7 @@ echo line3`,
 		})
 
 		ginkgo.It("should run a failing command and fail", func() {
-			controlOutput := []byte("bash: line 1: not-a-command: command not found\n")
+			controlOutput := []byte("bash: line 1: not-a-command: command not found")
 
 			cmd := exec.Command("../release/devpod-provider-ssh-linux-amd64", "command")
 			cmd.Env = append(cmd.Environ(), []string{
@@ -110,6 +110,8 @@ echo line3`,
 			}...)
 			output, err := cmd.CombinedOutput()
 			framework.ExpectError(err)
+
+			output = bytes.TrimSpace(output)
 
 			gomega.Expect(output).To(gomega.Equal(controlOutput))
 		})

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -121,7 +121,7 @@ func copyAndExecSSHCommand(provider *SSHProvider, command string, output io.Writ
 }
 
 func copyCommandToRemote(provider *SSHProvider, command string) (string, error) {
-	script, err := os.CreateTemp("/tmp/", "devpod-command-*")
+	script, err := os.CreateTemp("", "devpod-command-*")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/kballard/go-shellquote"
@@ -159,8 +160,10 @@ func getSCPCommand(provider *SSHProvider, sourcefile string) ([]string, error) {
 		result = append(result, flags...)
 	}
 
+	destfile := "/tmp/" + filepath.Base(sourcefile)
+
 	result = append(result, sourcefile)
-	result = append(result, provider.Config.Host+":"+sourcefile)
+	result = append(result, provider.Config.Host+":"+destfile)
 	return result, nil
 }
 


### PR DESCRIPTION
When non-posix shell is detected (i.e. fish) we fallback to copying a script + executing it instead of inline-executing

This is not default behaviour in order to preserve performance.

Fix https://github.com/loft-sh/devpod/issues/966
Resolve POD-133