### PR TITLE
fix: add option to use builtin SSH client, not enabled by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ release
 env
 devpod-provider-ssh
 e2e/bin
+.idea

--- a/README.md
+++ b/README.md
@@ -9,13 +9,43 @@ This repository hosts the default SSH provider configuration used in DevPod.
 To add this SSH provider from the CLI, use the `provider add` command. For example:
 
 ```shell
-# be sure to set $CURRENT_VERSION to an appropriate release tag from this repo
-devpod provider add https://github.com/loft-sh/devpod-provider-ssh/releases/download/$CURRENT_VERSION/provider.yaml
+devpod provider add ssh
 ```
 
 ## Compatibility
 
 We only support Linux machine as remote hosts.
+
+### Windows
+
+There are known issues with the default windows SSH installation in some setups. If you're unable to connect to your host by default,
+try to enable the `USE_BUILTIN_SSH` option
+```shell
+devpod provider add ssh --option USE_BUILTIN_SSH=true
+# or if already installed
+devpod provider set-options ssh --option USE_BUILTIN_SSH=true
+```
+
+This forces the provider to use the builtin SSH client over the one accessible in your shell. 
+You will need to add the identities file manually to your SSH config in case it's not the default key:
+```ssh
+Host my-domain.com
+    User my-user 
+    IdentityFile ~/.my-dir/my-key
+```
+
+## Options
+
+This provider has the following options:
+
+| NAME            | REQUIRED | DESCRIPTION                                                | DEFAULT           |
+|-----------------|----------|------------------------------------------------------------|-------------------|
+| HOST            | true     | The SSH Host to connect to. Example: my-user@my-domain.com |                   |
+| AGENT_PATH      | false    | The path where to inject the DevPod agent to.              | /tmp/devpod/agent |
+| DOCKER_PATH     | false    | The path of the docker binary.                             | docker            |
+| EXTRA_FLAGS     | false    | Extra flags to pass to the SSH command.                    |                   |
+| PORT            | false    | The SSH port to use.                                       | 22                |
+| USE_BUILTIN_SSH | false    | Use the builtin SSH package.                               | false             |
 
 # Extra
 

--- a/e2e/tests/provider/provider.go
+++ b/e2e/tests/provider/provider.go
@@ -20,6 +20,7 @@ var _ = ginkgo.Describe("[e2e]: devpod provider ssh test suite", ginkgo.Ordered,
 				"DOCKER_PATH=docker",
 				"HOST=localhost",
 				"PORT=1234",
+				"USE_BUILTIN_SSH=false",
 			}...)
 			err := cmd.Run()
 			framework.ExpectError(err)
@@ -33,6 +34,7 @@ var _ = ginkgo.Describe("[e2e]: devpod provider ssh test suite", ginkgo.Ordered,
 				"DOCKER_PATH=docker",
 				"HOST=localhost",
 				"PORT=22",
+				"USE_BUILTIN_SSH=false",
 			}...)
 			err := cmd.Run()
 			framework.ExpectNoError(err)
@@ -46,6 +48,7 @@ var _ = ginkgo.Describe("[e2e]: devpod provider ssh test suite", ginkgo.Ordered,
 				"DOCKER_PATH=docker",
 				"HOST=localhost",
 				"PORT=22",
+				"USE_BUILTIN_SSH=false",
 			}...)
 			err := cmd.Run()
 			framework.ExpectNoError(err)
@@ -63,6 +66,7 @@ var _ = ginkgo.Describe("[e2e]: devpod provider ssh test suite", ginkgo.Ordered,
 				"DOCKER_PATH=docker",
 				"HOST=localhost",
 				"PORT=22",
+				"USE_BUILTIN_SSH=false",
 			}...)
 			output, err := cmd.Output()
 			framework.ExpectNoError(err)
@@ -90,6 +94,7 @@ echo line2
 echo line3`,
 				"HOST=localhost",
 				"PORT=22",
+				"USE_BUILTIN_SSH=false",
 			}...)
 			output, err := cmd.CombinedOutput()
 			framework.ExpectNoError(err)
@@ -107,6 +112,7 @@ echo line3`,
 				"DOCKER_PATH=docker",
 				"HOST=localhost",
 				"PORT=22",
+				"USE_BUILTIN_SSH=false",
 			}...)
 			output, err := cmd.CombinedOutput()
 			framework.ExpectError(err)

--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -8,6 +8,7 @@ optionGroups:
   - options:
       - PORT
       - EXTRA_FLAGS
+      - USE_BUILTIN_SSH
     name: "SSH options"
     defaultVisible: false
   - options:
@@ -41,6 +42,10 @@ options:
     default: "22"
   EXTRA_FLAGS:
     description: "Extra flags to pass to the SSH command."
+  USE_BUILTIN_SSH:
+    description: "Use the builtin SSH package."
+    default: false
+    type: boolean
 agent:
   inactivityTimeout: ${INACTIVITY_TIMEOUT}
   injectGitCredentials: ${INJECT_GIT_CREDENTIALS}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -6,20 +6,22 @@ import (
 )
 
 var (
-	DOCKER_PATH = "DOCKER_PATH"
-	AGENT_PATH  = "AGENT_PATH"
-	HOST        = "HOST"
-	PORT        = "PORT"
-	EXTRA_FLAGS = "EXTRA_FLAGS"
+	DOCKER_PATH     = "DOCKER_PATH"
+	AGENT_PATH      = "AGENT_PATH"
+	HOST            = "HOST"
+	PORT            = "PORT"
+	EXTRA_FLAGS     = "EXTRA_FLAGS"
+	USE_BUILTIN_SSH = "USE_BUILTIN_SSH"
 )
 
 type Options struct {
-	DockerPath string
-	AgentPath  string
-	User       string
-	Host       string
-	Port       string
-	ExtraFlags string
+	DockerPath    string
+	AgentPath     string
+	User          string
+	Host          string
+	Port          string
+	ExtraFlags    string
+	UseBuiltinSSH bool
 }
 
 func FromEnv() (*Options, error) {
@@ -48,6 +50,12 @@ func FromEnv() (*Options, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	builtinSSH, err := fromEnvOrError(USE_BUILTIN_SSH)
+	if err != nil {
+		return nil, err
+	}
+	retOptions.UseBuiltinSSH = builtinSSH == "true"
 
 	return retOptions, nil
 }

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -73,7 +72,7 @@ func getSSHCommand(provider *SSHProvider) ([]string, error) {
 }
 
 func execSSHCommand(provider *SSHProvider, command string, output io.Writer) error {
-	if runtime.GOOS == "windows" {
+	if provider.Config.UseBuiltinSSH {
 		// get ssh config for host
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		defer cancel()
@@ -178,8 +177,8 @@ func copyCommandToRemote(provider *SSHProvider, command string) (string, error) 
 		return "", err
 	}
 	defer func() {
-		script.Close()
-		os.Remove(script.Name())
+		_ = script.Close()
+		_ = os.Remove(script.Name())
 	}()
 
 	commandToRun, err := getSCPCommand(provider, script.Name())


### PR DESCRIPTION
On some windows machines the builtin SSH library doesn't play well with DevPod. Originally we've tried to fix this by using our own SSH client. A couple of users reported this change broke their setup. We're rolling back the default on windows and instead offer it as a workaround via the `USE_BUILTIN_SSH` option. Updated readme for troubleshooting